### PR TITLE
chore: Bumped Husky version

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx --no -- commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "fastify": "^4.25.2",
-        "husky": "^9.0.7",
+        "husky": "^9.0.11",
         "lint-staged": "^15.2.0",
         "mercurius": "^14.0.0",
         "pg": "^8.11.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "test": "c8 node --test src/",
     "test:watch": "c8 node --test --watch src/",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "fastify": "^4.25.2",
-    "husky": "^9.0.7",
+    "husky": "^9.0.11",
     "lint-staged": "^15.2.0",
     "mercurius": "^14.0.0",
     "pg": "^8.11.3",


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)