### PR TITLE
chore: use strict assertions in type tests

### DIFF
--- a/types/core.tst.ts
+++ b/types/core.tst.ts
@@ -1,3 +1,4 @@
+import type { GraphQLSchema } from 'graphql'
 import { expect, test, describe } from 'tstyche'
 import {
   encodeCursor,
@@ -28,22 +29,14 @@ describe('decodeCursor function', () => {
 
 describe('ConnectionArgs type', () => {
   test('should accept first and after properties', () => {
-    expect({
+    expect<ConnectionArgs>().type.toBeAssignableWith({
       first: 10,
       after: 'cursor123'
-    }).type.toBeAssignableTo<ConnectionArgs>()
+    })
   })
 
   test('should accept only first property', () => {
     expect<ConnectionArgs>().type.toBeAssignableWith({ first: 5 })
-  })
-
-  test('should accept first with optional after', () => {
-    expect({ first: 10 }).type.toBeAssignableTo<ConnectionArgs>()
-    expect({
-      first: 10,
-      after: 'cursor'
-    }).type.toBeAssignableTo<ConnectionArgs>()
   })
 })
 
@@ -64,7 +57,7 @@ describe('ConnectionResolverResponse type', () => {
   type Post = { id: number; title: string; content: string }
 
   test('should accept basic connection response with User type', () => {
-    expect({
+    expect<ConnectionResolverResponse<User>>().type.toBe({
       edges: [
         {
           cursor: 'cursor1',
@@ -81,11 +74,11 @@ describe('ConnectionResolverResponse type', () => {
         hasPreviousPage: false,
         hasNextPage: true
       }
-    }).type.toBeAssignableTo<ConnectionResolverResponse<User>>()
+    })
   })
 
   test('should accept connection response with Post type', () => {
-    expect({
+    expect<ConnectionResolverResponse<Post>>().type.toBe({
       edges: [
         {
           cursor: 'post1',
@@ -98,11 +91,11 @@ describe('ConnectionResolverResponse type', () => {
         hasPreviousPage: false,
         hasNextPage: false
       }
-    }).type.toBeAssignableTo<ConnectionResolverResponse<Post>>()
+    })
   })
 
   test('should accept empty edges array', () => {
-    expect({
+    expect<ConnectionResolverResponse<User>>().type.toBeAssignableWith({
       edges: [],
       pageInfo: {
         startCursor: 'start',
@@ -110,36 +103,15 @@ describe('ConnectionResolverResponse type', () => {
         hasPreviousPage: false,
         hasNextPage: false
       }
-    }).type.toBeAssignableTo<ConnectionResolverResponse<User>>()
-  })
-
-  test('should validate edge structure', () => {
-    expect({
-      cursor: 'test',
-      node: { id: '1', name: 'Test' }
-    }).type.toBe<{ cursor: string; node: User }>()
-  })
-
-  test('should validate pageInfo structure', () => {
-    expect({
-      startCursor: 'start',
-      endCursor: 'end',
-      hasPreviousPage: true,
-      hasNextPage: false
-    }).type.toBeAssignableTo<{
-      startCursor: string
-      endCursor: string
-      hasPreviousPage: boolean
-      hasNextPage: boolean
-    }>()
+    })
   })
 })
 
 describe('connectionDirective function', () => {
   test('should return correct type with no parameters', () => {
-    expect(connectionDirective()).type.toBeAssignableTo<{
+    expect(connectionDirective()).type.toBe<{
       connectionDirectiveTypeDefs: string
-      connectionDirectiveTransformer: (schema: any) => any
+      connectionDirectiveTransformer: (schema: GraphQLSchema) => GraphQLSchema
     }>()
   })
 
@@ -151,9 +123,9 @@ describe('connectionDirective function', () => {
           encodeCursor: true
         }
       })
-    ).type.toBeAssignableTo<{
+    ).type.toBe<{
       connectionDirectiveTypeDefs: string
-      connectionDirectiveTransformer: (schema: any) => any
+      connectionDirectiveTransformer: (schema: GraphQLSchema) => GraphQLSchema
     }>()
   })
 
@@ -176,16 +148,16 @@ describe('connectionDirective function', () => {
         },
         'customPagination'
       )
-    ).type.toBeAssignableTo<{
+    ).type.toBe<{
       connectionDirectiveTypeDefs: string
-      connectionDirectiveTransformer: (schema: any) => any
+      connectionDirectiveTransformer: (schema: GraphQLSchema) => GraphQLSchema
     }>()
   })
 })
 
 describe('ConnectionProperties type constraints', () => {
   test('should accept basic connection properties', () => {
-    expect({
+    expect(connectionDirective).type.toBeCallableWith({
       User: {
         paginationMode: 'simple' as const,
         encodeCursor: true
@@ -194,31 +166,31 @@ describe('ConnectionProperties type constraints', () => {
         paginationMode: 'edges' as const,
         encodeCursor: false
       }
-    }).type.toBeAssignableTo<Parameters<typeof connectionDirective>[0]>()
+    })
   })
 
   test('should accept cursorPropOrFn as string', () => {
-    expect({
+    expect(connectionDirective).type.toBeCallableWith({
       User: {
         paginationMode: 'simple' as const,
         encodeCursor: true,
         cursorPropOrFn: 'id'
       }
-    }).type.toBeAssignableTo<Parameters<typeof connectionDirective>[0]>()
+    })
   })
 
   test('should accept cursorPropOrFn as function', () => {
-    expect({
+    expect(connectionDirective).type.toBeCallableWith({
       User: {
         paginationMode: 'simple' as const,
         encodeCursor: true,
         cursorPropOrFn: (item: unknown[]) => `cursor_${item.length}`
       }
-    }).type.toBeAssignableTo<Parameters<typeof connectionDirective>[0]>()
+    })
   })
 
   test('should accept nested connectionProps and edgeProps', () => {
-    expect({
+    expect(connectionDirective).type.toBeCallableWith({
       User: {
         paginationMode: 'simple' as const,
         encodeCursor: true,
@@ -231,20 +203,15 @@ describe('ConnectionProperties type constraints', () => {
           config: { sortable: 'true' }
         }
       }
-    }).type.toBeAssignableTo<Parameters<typeof connectionDirective>[0]>()
+    })
   })
 
   test('should accept directiveName parameter', () => {
-    expect(
-      connectionDirective(undefined, 'myPagination')
-    ).type.toBeAssignableTo<{
-      connectionDirectiveTypeDefs: string
-      connectionDirectiveTransformer: (schema: any) => any
-    }>()
+    expect(connectionDirective).type.toBeCallableWith(undefined, 'myPagination')
   })
 
   test('should accept all optional connection properties', () => {
-    expect({
+    expect(connectionDirective).type.toBeCallableWith({
       ComplexType: {
         paginationMode: 'edges' as const,
         encodeCursor: true,
@@ -258,6 +225,6 @@ describe('ConnectionProperties type constraints', () => {
           metadata: { importance: 'high' }
         }
       }
-    }).type.toBeAssignableTo<Parameters<typeof connectionDirective>[0]>()
+    })
   })
 })

--- a/types/utils.tst.ts
+++ b/types/utils.tst.ts
@@ -25,8 +25,8 @@ describe('NodesOnly utility type', () => {
       type TransformedResolvers = NodesOnly<SimpleResolvers>
 
       // Test that the transformation preserves the general structure
-      expect({} as TransformedResolvers).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedResolvers>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
 
@@ -34,7 +34,7 @@ describe('NodesOnly utility type', () => {
       type EmptyResolvers = {}
       type TransformedEmpty = NodesOnly<EmptyResolvers>
 
-      expect({} as TransformedEmpty).type.toBe<{}>()
+      expect<TransformedEmpty>().type.toBe<{}>()
     })
   })
 
@@ -53,8 +53,8 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedNestedObject = NodesOnly<NestedResolverObject>
-      expect({} as TransformedNestedObject).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedNestedObject>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
 
@@ -80,8 +80,8 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedNested = NodesOnly<NestedResolvers>
-      expect({} as TransformedNested).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedNested>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
   })
@@ -118,14 +118,14 @@ describe('NodesOnly utility type', () => {
       type TransformedMixed = NodesOnly<MixedResolvers>
 
       // Test that the transformation produces a valid object type
-      expect({} as TransformedMixed).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedMixed>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
 
       // Test that the top-level keys are preserved
-      expect({} as TransformedMixed).type.toBeAssignableTo<{
-        Query: any
-        User: any
+      expect<TransformedMixed>().type.toBeAssignableTo<{
+        Query: unknown
+        User: unknown
       }>()
     })
 
@@ -138,8 +138,8 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedFunctions = NodesOnly<FunctionResolvers>
-      expect({} as TransformedFunctions).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedFunctions>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
   })
@@ -157,8 +157,8 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedOptional = NodesOnly<OptionalResolvers>
-      expect({} as TransformedOptional).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedOptional>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
 
@@ -174,8 +174,8 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedOptionalNodes = NodesOnly<OptionalNodeResolvers>
-      expect({} as TransformedOptionalNodes).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedOptionalNodes>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
   })
@@ -201,8 +201,8 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedComplexEdges = NodesOnly<ComplexEdgeResolvers>
-      expect({} as TransformedComplexEdges).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedComplexEdges>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
 
@@ -230,8 +230,8 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedMultiConnection = NodesOnly<MultiConnectionResolvers>
-      expect({} as TransformedMultiConnection).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedMultiConnection>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
   })
@@ -249,10 +249,10 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedGeneric = NodesOnly<
-        GenericResolvers<{ id: string; data: any }>
+        GenericResolvers<{ id: string; data: unknown }>
       >
-      expect({} as TransformedGeneric).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedGeneric>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
 
@@ -270,8 +270,8 @@ describe('NodesOnly utility type', () => {
       type TransformedConstrainedGeneric = NodesOnly<
         ConstrainedGenericResolvers<{ id: string; name: string }>
       >
-      expect({} as TransformedConstrainedGeneric).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedConstrainedGeneric>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
   })
@@ -289,17 +289,17 @@ describe('NodesOnly utility type', () => {
       }
 
       type TransformedReadonly = NodesOnly<ReadonlyArrayResolvers>
-      expect({} as TransformedReadonly).type.toBeAssignableTo<
-        Record<string, any>
+      expect<TransformedReadonly>().type.toBeAssignableTo<
+        Record<string, unknown>
       >()
     })
   })
 
   describe('NodesOnly constraint validation', () => {
-    test('should work with Record<string, any>', () => {
-      expect({
+    test('should work with Record<string, unknown>', () => {
+      expect<NodesOnly<{ test: { field: string } }>>().type.toBeAssignableWith({
         test: { field: 'value' }
-      }).type.toBeAssignableTo<NodesOnly<{ test: { field: string } }>>()
+      })
     })
   })
 })


### PR DESCRIPTION
Close #260

This PR makes the assertions stricter in type tests:

- `.toBeAssignableTo()` is replaced with `.toBe()` (when possible)
- `any` is replaced `unknown` (where possible)

Additionally in some places I move the type under test to the left side of assertion. A minor refactor, but it makes tests more readable.